### PR TITLE
add blank line to release message

### DIFF
--- a/src/GToolkit-Releaser/GtRlRepositoryRelease.class.st
+++ b/src/GToolkit-Releaser/GtRlRepositoryRelease.class.st
@@ -88,7 +88,7 @@ GtRlRepositoryRelease >> commitMessageForRelease [
 				nextPutAll: 'Metacello new
     baseline: ''', localRootProjects first name, ''';
     repository: ''', self urlWithReleaseVersion asString,  ''';
-    load'.
+    load' ; lf.
 			self isRootRepositoryRelease ifTrue: [  
 				commits := self printNewCommitsToString.
 				(commits isNotEmpty) ifTrue: [


### PR DESCRIPTION
Adds a blank line after the Metacello script.

Metacello new
    baseline: 'GToolkit';
    repository: 'github://feenkcom/gtoolkit:v0.8.625/src';
    load

All commits (including upstream repositories) since last build:
https://github.com/feenkcom/gtoolkit/commit/8d9539 by George Ganea
don't need to exit after killing the process